### PR TITLE
Improve lookup performance

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,13 @@ pub use crate::level::*;
 pub use crate::metadata::*;
 
 process_local! {
-    static LOGGING_PROCESS: RefCell<Option<Process<Event>>> = RefCell::new(None);
+    static LOGGING_PROCESS: RefCell<LoggingProcess> = RefCell::new(LoggingProcess::NotLookedUp);
+}
+
+enum LoggingProcess {
+    NotLookedUp,
+    NotPresent,
+    Present(Process<Event>),
 }
 
 /// Initialize a subscriber to log events.
@@ -25,6 +31,7 @@ pub fn init(subscriber: impl Subscriber) -> Process<Event> {
 
     let process = spawn_subscriber(subscriber);
     process.register("lunatic::logger");
+    LOGGING_PROCESS.with_borrow_mut(|mut proc| *proc = LoggingProcess::Present(process.clone()));
     process
 }
 
@@ -67,14 +74,18 @@ impl Event {
 // This is an internal function, and it's API is subject to change at any time.
 #[doc(hidden)]
 pub fn __lookup_logging_process() -> Option<Process<Event>> {
-    LOGGING_PROCESS.with(|proc| {
-        if proc.borrow().is_none() {
-            return Process::<Event>::lookup("lunatic::logger").map(|process| {
-                *proc.borrow_mut() = Some(process.clone());
-                process
-            });
-        }
-
-        proc.borrow().clone()
+    LOGGING_PROCESS.with(|proc| match &*proc.borrow() {
+        LoggingProcess::NotLookedUp => match Process::<Event>::lookup("lunatic::logger") {
+            Some(process) => {
+                *proc.borrow_mut() = LoggingProcess::Present(process.clone());
+                Some(process)
+            }
+            None => {
+                *proc.borrow_mut() = LoggingProcess::NotPresent;
+                None
+            }
+        },
+        LoggingProcess::NotPresent => None,
+        LoggingProcess::Present(process) => Some(process.clone()),
     })
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -3,28 +3,28 @@ macro_rules! log {
     // log!(target: "my_target", Level::Info; "a {} event", "log");
     (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
         use lunatic::process::Message;
-        let metadata = $crate::Metadata::new(
-            concat!(
-                "event ",
-                file!(),
-                ":",
-                line!()
-            ).to_string(),
-            $target.into(),
-            $lvl,
-            Some(module_path!().to_string()),
-            Some(file!().to_string()),
-            Some(line!()),
-        );
-        let message = format!($($arg)+);
-        let event = $crate::Event::new(message, metadata);
         if let Some(proc) = $crate::__lookup_logging_process() {
+            let metadata = $crate::Metadata::new(
+                concat!(
+                    "event ",
+                    file!(),
+                    ":",
+                    line!()
+                ).to_string(),
+                $target.into(),
+                $lvl,
+                Some(module_path!().to_string()),
+                Some(file!().to_string()),
+                Some(line!()),
+            );
+            let message = format!($($arg)+);
+            let event = $crate::Event::new(message, metadata);
             proc.send(event)
         }
     });
 
     // log!(Level::Info, "a log event")
-    ($lvl:expr, $($arg:tt)+) => ($crate::log!(target: module_path!().to_string(), $lvl, $($arg)+));
+    ($lvl:expr, $($arg:tt)+) => ($crate::log!(target: module_path!(), $lvl, $($arg)+));
 }
 
 /// Logs a message at the error level.


### PR DESCRIPTION
Improves lookup and logging performance by:
- No allocations are made if subscriber process is not present
- Subscriber process is lookup only once per process, regardless of if it exists or not.
  Previously a lookup would occur for each log if the process was not present. 