### PR TITLE
Bump lunatic version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,10 @@ categories = ["wasm", "development-tools::debugging"]
 license = "Apache-2.0/MIT"
 readme = "Readme.md"
 
-
 [dependencies]
 ansi_term = "0.12"
 chrono = "0.4"
-lunatic = "^0.10"
+lunatic = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
Bump lunatic version to `0.11`. I didn't add the caret (`^0.11`) since apparently it's already the default.
<https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#caret-requirements>

> `^1.2.3` is exactly equivalent to `1.2.3`.

I was considering bumping the version to `>=0.10,<0.12`, but I think it's more simple to just do `0.11`.