### PR TITLE
Removing 'we got an event' output

### DIFF
--- a/src/subscriber/multiple.rs
+++ b/src/subscriber/multiple.rs
@@ -35,7 +35,6 @@ impl Subscriber for MultipleSubscribers {
     }
 
     fn event(&self, event: &Event) {
-        println!("we got an event");
         for subscriber in &self.subscribers {
             subscriber.send(event.clone());
         }


### PR DESCRIPTION
Noticed that when using the `MultipleSubscribers` that this line was being printed on every event.